### PR TITLE
Add phyloframe project documentation to blog

### DIFF
--- a/blog_efflux/_posts/2026-03-02-phyloframe.md
+++ b/blog_efflux/_posts/2026-03-02-phyloframe.md
@@ -1,0 +1,17 @@
+---
+layout: efflux
+title: "phyloframe"
+date: 2026-03-02
+category: research
+view_github: https://github.com/mmore500/phyloframe
+view_publisher: https://pypi.org/project/phyloframe/
+authors:
+  - Matthew Andres Moreno
+description: |
+  phyloframe provides dataframe-based tools for working with phylogenetic trees.
+venue: Python package published via PyPI
+projects:
+  - libraries
+supporting_materials: |
+  - [documentation](https://github.com/mmore500/phyloframe/blob/master/README.md) [via GitHub <i class="icon-github-1"></i>](https://github.com/)
+---


### PR DESCRIPTION
## Summary
This PR adds a new blog post documenting the phyloframe project, a Python package for dataframe-based phylogenetic tree manipulation.

## Changes
- Added new blog post entry for phyloframe project (`blog_efflux/_posts/2026-03-02-phyloframe.md`)
  - Includes project metadata (title, date, category)
  - Links to GitHub repository and PyPI package page
  - Provides brief description of the project's purpose
  - References documentation and supporting materials
  - Categorizes under "libraries" project type

## Details
The post documents phyloframe as a research project published via PyPI, with links to both the source code repository and package distribution. The entry follows the existing blog post structure and includes relevant metadata for categorization and discovery.

https://claude.ai/code/session_01EVMN4UcDWAfxsGV94kYpng