### PR TITLE
Add Simon et al. 2026 preprint on allele-based coronavirus evolution

### DIFF
--- a/blog_efflux/_posts/2025-09-15-simon2025allele.md
+++ b/blog_efflux/_posts/2025-09-15-simon2025allele.md
@@ -37,5 +37,5 @@ bibtex: |-
   }
 citation: "Simon C. P., Koopman J. S., Eisenberg M. C., Zaman L., Moreno M. A., & Polanco A. (2025). An allele-based model of coronavirus evolution under population immunity. medRxiv. https://doi.org/10.1101/2025.09.15.25335781"
 supporting_materials: |
-  - [supplementary material](https://www.medrxiv.org/content/10.1101/2025.09.15.25335781v3.supplementary-material) [via medRxiv](https://www.medrxiv.org/)
+  - [supplementary material](https://www.medrxiv.org/content/10.1101/2025.09.15.25335781.supplementary-material) [via medRxiv](https://www.medrxiv.org/)
 ---

--- a/blog_efflux/_posts/2025-09-15-simon2025allele.md
+++ b/blog_efflux/_posts/2025-09-15-simon2025allele.md
@@ -36,4 +36,6 @@ bibtex: |-
     journal = {medRxiv}
   }
 citation: "Simon C. P., Koopman J. S., Eisenberg M. C., Zaman L., Moreno M. A., & Polanco A. (2025). An allele-based model of coronavirus evolution under population immunity. medRxiv. https://doi.org/10.1101/2025.09.15.25335781"
+supporting_materials: |
+  - [supplementary material](https://www.medrxiv.org/content/10.1101/2025.09.15.25335781v3.supplementary-material) [via medRxiv](https://www.medrxiv.org/)
 ---

--- a/blog_efflux/_posts/2025-09-15-simon2025allele.md
+++ b/blog_efflux/_posts/2025-09-15-simon2025allele.md
@@ -32,7 +32,7 @@ bibtex: |-
     title = {An allele-based model of coronavirus evolution under population immunity},
     author = {Carl P. Simon and James S. Koopman and Marisa C. Eisenberg and Luis Zaman and Matthew Andres Moreno and Austin Polanco},
     year = {2025},
-    publisher = {Cold Spring Harbor Laboratory Press},
+    publisher = {openRxiv},
     journal = {medRxiv}
   }
 citation: "Simon C. P., Koopman J. S., Eisenberg M. C., Zaman L., Moreno M. A., & Polanco A. (2025). An allele-based model of coronavirus evolution under population immunity. medRxiv. https://doi.org/10.1101/2025.09.15.25335781"

--- a/blog_efflux/_posts/2025-09-15-simon2025allele.md
+++ b/blog_efflux/_posts/2025-09-15-simon2025allele.md
@@ -1,0 +1,39 @@
+---
+layout: efflux
+title: "An allele-based model of coronavirus evolution under population immunity"
+date: 2025-09-15
+permalink: "/pubs/:title"
+category: preprint
+doi: 10.1101/2025.09.15.25335781
+download: https://www.medrxiv.org/content/10.1101/2025.09.15.25335781v3.full.pdf
+view_publisher: https://doi.org/10.1101/2025.09.15.25335781
+authors:
+  - Carl P. Simon
+  - James S. Koopman
+  - Marisa C. Eisenberg
+  - Luis Zaman
+  - Matthew Andres Moreno
+  - Austin Polanco
+venue: medRxiv
+projects:
+abstract: |
+  Most epidemic models represent viral evolution at the level of whole strains, assigning transmissibility and immune escape directly to variants.
+  However, in reality, mutations occur at specific genomic sites, and the epidemiological consequences of viral evolution depend on how these allele-level changes interact with population immunity.
+  We develop a compartmental model in which viral strains are defined by combinations of alleles across genomic sites, while transmission, immunity, waning, and mutation operate at the allele level.
+  This framework allows evolutionary pressures acting on individual genomic components to propagate across multiple strains.
+  Even in a minimal system with two sites and two alleles per site, the model generates rich dynamics.
+  Epidemic waves of an initially seeded strain produce an immune landscape that often favors genetically complementary strains.
+  More generally, four mechanisms shape strain success: increases in prevalence of a strain due to increased transmissibility or immunity-avoidance of its underlying alleles, complementarity effects driven by population immunity, founder effects that indirectly favor the initially circulating strain, and adjacency effects associated with mutation pathways.
+  These results show that immune structure can redirect viral evolution in ways not captured by strain-based models and provide a simple framework linking viral genetics with epidemic dynamics.
+bibtex: |-
+  @misc{simon2025allele,
+    doi = {10.1101/2025.09.15.25335781},
+    url = {https://www.medrxiv.org/content/10.1101/2025.09.15.25335781v3},
+    title = {An allele-based model of coronavirus evolution under population immunity},
+    author = {Carl P. Simon and James S. Koopman and Marisa C. Eisenberg and Luis Zaman and Matthew Andres Moreno and Austin Polanco},
+    year = {2025},
+    publisher = {Cold Spring Harbor Laboratory Press},
+    journal = {medRxiv}
+  }
+citation: "Simon C. P., Koopman J. S., Eisenberg M. C., Zaman L., Moreno M. A., & Polanco A. (2025). An allele-based model of coronavirus evolution under population immunity. medRxiv. https://doi.org/10.1101/2025.09.15.25335781"
+---

--- a/blog_efflux/_posts/2026-05-11-simon2026allele.md
+++ b/blog_efflux/_posts/2026-05-11-simon2026allele.md
@@ -19,11 +19,14 @@ projects:
 abstract: |
   Most epidemic models represent viral evolution at the level of whole strains, assigning transmissibility and immune escape directly to variants.
   However, in reality, mutations occur at specific genomic sites, and the epidemiological consequences of viral evolution depend on how these allele-level changes interact with population immunity.
+
   We develop a compartmental model in which viral strains are defined by combinations of alleles across genomic sites, while transmission, immunity, waning, and mutation operate at the allele level.
   This framework allows evolutionary pressures acting on individual genomic components to propagate across multiple strains.
+
   Even in a minimal system with two sites and two alleles per site, the model generates rich dynamics.
   Epidemic waves of an initially seeded strain produce an immune landscape that often favors genetically complementary strains.
   More generally, four mechanisms shape strain success: increases in prevalence of a strain due to increased transmissibility or immunity-avoidance of its underlying alleles, complementarity effects driven by population immunity, founder effects that indirectly favor the initially circulating strain, and adjacency effects associated with mutation pathways.
+
   These results show that immune structure can redirect viral evolution in ways not captured by strain-based models and provide a simple framework linking viral genetics with epidemic dynamics.
 bibtex: |-
   @misc{simon2026allele,

--- a/blog_efflux/_posts/2026-05-11-simon2026allele.md
+++ b/blog_efflux/_posts/2026-05-11-simon2026allele.md
@@ -1,11 +1,11 @@
 ---
 layout: efflux
 title: "An allele-based model of coronavirus evolution under population immunity"
-date: 2025-09-15
+date: 2026-05-11
 permalink: "/pubs/:title"
 category: preprint
 doi: 10.1101/2025.09.15.25335781
-download: https://www.medrxiv.org/content/10.1101/2025.09.15.25335781v3.full.pdf
+download: https://www.medrxiv.org/content/10.1101/2025.09.15.25335781.full.pdf
 view_publisher: https://doi.org/10.1101/2025.09.15.25335781
 authors:
   - Carl P. Simon
@@ -26,16 +26,16 @@ abstract: |
   More generally, four mechanisms shape strain success: increases in prevalence of a strain due to increased transmissibility or immunity-avoidance of its underlying alleles, complementarity effects driven by population immunity, founder effects that indirectly favor the initially circulating strain, and adjacency effects associated with mutation pathways.
   These results show that immune structure can redirect viral evolution in ways not captured by strain-based models and provide a simple framework linking viral genetics with epidemic dynamics.
 bibtex: |-
-  @misc{simon2025allele,
+  @misc{simon2026allele,
     doi = {10.1101/2025.09.15.25335781},
-    url = {https://www.medrxiv.org/content/10.1101/2025.09.15.25335781v3},
+    url = {https://doi.org/10.1101/2025.09.15.25335781},
     title = {An allele-based model of coronavirus evolution under population immunity},
     author = {Carl P. Simon and James S. Koopman and Marisa C. Eisenberg and Luis Zaman and Matthew Andres Moreno and Austin Polanco},
-    year = {2025},
+    year = {2026},
     publisher = {openRxiv},
     journal = {medRxiv}
   }
-citation: "Simon C. P., Koopman J. S., Eisenberg M. C., Zaman L., Moreno M. A., & Polanco A. (2025). An allele-based model of coronavirus evolution under population immunity. medRxiv. https://doi.org/10.1101/2025.09.15.25335781"
+citation: "Simon C. P., Koopman J. S., Eisenberg M. C., Zaman L., Moreno M. A., & Polanco A. (2026). An allele-based model of coronavirus evolution under population immunity. medRxiv. https://doi.org/10.1101/2025.09.15.25335781"
 supporting_materials: |
   - [supplementary material](https://www.medrxiv.org/content/10.1101/2025.09.15.25335781.supplementary-material) [via medRxiv](https://www.medrxiv.org/)
 ---

--- a/blog_efflux/_posts/2026-05-11-simon2026allele.md
+++ b/blog_efflux/_posts/2026-05-11-simon2026allele.md
@@ -31,6 +31,7 @@ bibtex: |-
     url = {https://doi.org/10.1101/2025.09.15.25335781},
     title = {An allele-based model of coronavirus evolution under population immunity},
     author = {Carl P. Simon and James S. Koopman and Marisa C. Eisenberg and Luis Zaman and Matthew Andres Moreno and Austin Polanco},
+    month = may,
     year = {2026},
     publisher = {openRxiv},
     journal = {medRxiv}

--- a/blog_efflux/_posts/2026-05-11-simon2026allele.md
+++ b/blog_efflux/_posts/2026-05-11-simon2026allele.md
@@ -5,7 +5,7 @@ date: 2026-05-11
 permalink: "/pubs/:title"
 category: preprint
 doi: 10.1101/2025.09.15.25335781
-download: https://www.medrxiv.org/content/10.1101/2025.09.15.25335781.full.pdf
+download: https://www.medrxiv.org/content/10.1101/2025.09.15.25335781v3.full.pdf
 view_publisher: https://doi.org/10.1101/2025.09.15.25335781
 authors:
   - Carl P. Simon


### PR DESCRIPTION
## Summary
This PR adds a new publication entry to the blog for a medRxiv preprint on allele-based modeling of coronavirus evolution under population immunity.

## Changes
- Added new publication post: `blog_efflux/_posts/2026-05-11-simon2026allele.md`
  - Includes complete publication metadata (DOI, authors, venue)
  - Contains abstract describing the allele-level epidemic modeling framework
  - Provides BibTeX citation and formatted citation text
  - Links to supplementary materials on medRxiv

## Details
The publication describes a compartmental model that represents viral strains as combinations of alleles across genomic sites, allowing evolutionary pressures at the allele level to propagate across multiple strains. The post follows the existing efflux layout and categorization conventions.

https://claude.ai/code/session_01G8gdL3R7fwfv6m1aummXu3