### PR TITLE
Add PhyloFrame preprint publication to blog

### DIFF
--- a/blog_efflux/_posts/2026-05-27-moreno2026phyloframe.md
+++ b/blog_efflux/_posts/2026-05-27-moreno2026phyloframe.md
@@ -36,4 +36,5 @@ supporting_materials: |
   - [software repository](https://github.com/mmore500/phyloframe) [via GitHub <i class="icon-github-1"></i>](https://github.com/)
   - [software package](https://pypi.org/project/phyloframe/) [via PyPI](https://pypi.org/)
   - [documentation](https://phyloframe.readthedocs.io) [via Read the Docs](https://readthedocs.org/)
+  - [data](https://osf.io/knw8x/) [via Open Science Framework ❋](https://osf.io)
 ---

--- a/blog_efflux/_posts/2026-05-27-moreno2026phyloframe.md
+++ b/blog_efflux/_posts/2026-05-27-moreno2026phyloframe.md
@@ -16,10 +16,19 @@ venue: arXiv
 projects:
   - libraries
 abstract: |
-  PhyloFrame is a Python library for phylogenetic computation targeting the gap between specialist, compiler-optimized operations and flexible, script-based workflows -- with emphasis on fast, memory-efficient operations for very large tree sizes (e.g., ≥ 300,000 taxa).
+  PhyloFrame is a Python library for phylogenetic computation targeting the gap between specialist, compiler-optimized operations and flexible, script-based workflows --- with emphasis on fast, memory-efficient operations for very large tree sizes (e.g., ≥ 300,000 taxa).
   PhyloFrame is built around a DataFrame-based tree representation, where each row corresponds to a node and columns record ancestor relationships, branch lengths, taxon labels, and any user-defined attributes.
   Crucial for scalability, such array-backed storage allows both library and end-user code alike to seamlessly harness Just-in-Time (JIT) compilation (e.g., Numba) and vectorized execution (e.g., NumPy, Polars).
   At large tree sizes, performance generally matches or exceeds Python libraries backed by native code -- notably, achieving strong performance in topological-order traversals and Newick I/O.
+
+  DataFrame-based representation affords several additional conveniences, including:
+  
+  - succinct bulk operations (e.g., NumPy);
+  - powerful queries and transformations (e.g., Polars expressions, Pandas indexing, SQL-style joins and merges);
+  - compatibility with modern tabular data formats that are compression-friendly, type-aware, nullable, and highly portable (e.g., Parquet); and
+  - broad interoperation with table-oriented data science tools (e.g., Seaborn, Plotly, Vega-Altair, tidyverse, Excel).
+
+  Current library features include tree input/output, synthetic tree generation, taxon-based queries, tree traversals, tree metrics, tree manipulation, tree downsampling, and tree comparison. Most functionality supports both Pandas and Polars DataFrames, and is available through programmatic and CLI-based interfaces.
 bibtex: |-
   @misc{moreno2026phyloframe,
         doi={10.48550/arXiv.2605.28545},

--- a/blog_efflux/_posts/2026-05-27-moreno2026phyloframe.md
+++ b/blog_efflux/_posts/2026-05-27-moreno2026phyloframe.md
@@ -1,0 +1,39 @@
+---
+layout: efflux
+title: "PhyloFrame: A DataFrame-based Library for Fast, Flexible Phylogenetic Computation"
+date: 2026-05-27
+permalink: "/pubs/:title"
+category: preprint
+doi: 10.48550/arXiv.2605.28545
+download: https://arxiv.org/pdf/2605.28545.pdf
+view_publisher: https://doi.org/10.48550/arXiv.2605.28545
+authors:
+  - Matthew Andres Moreno
+  - Jeet Sukumaran
+  - Luis Zaman
+  - Emily Dolson
+venue: arXiv
+projects:
+  - libraries
+abstract: |
+  PhyloFrame is a Python library for phylogenetic computation targeting the gap between specialist, compiler-optimized operations and flexible, script-based workflows -- with emphasis on fast, memory-efficient operations for very large tree sizes (e.g., ≥ 300,000 taxa).
+  PhyloFrame is built around a DataFrame-based tree representation, where each row corresponds to a node and columns record ancestor relationships, branch lengths, taxon labels, and any user-defined attributes.
+  Crucial for scalability, such array-backed storage allows both library and end-user code alike to seamlessly harness Just-in-Time (JIT) compilation (e.g., Numba) and vectorized execution (e.g., NumPy, Polars).
+  At large tree sizes, performance generally matches or exceeds Python libraries backed by native code -- notably, achieving strong performance in topological-order traversals and Newick I/O.
+bibtex: |-
+  @misc{moreno2026phyloframe,
+        doi={10.48550/arXiv.2605.28545},
+        url={https://arxiv.org/abs/2605.28545},
+        title={PhyloFrame: A DataFrame-based Library for Fast, Flexible Phylogenetic Computation},
+        author={Matthew Andres Moreno and Jeet Sukumaran and Luis Zaman and Emily Dolson},
+        year={2026},
+        eprint={2605.28545},
+        archivePrefix={arXiv},
+        primaryClass={q-bio.PE},
+  }
+citation: "Moreno M. A., Sukumaran J., Zaman L., & Dolson E. (2026). PhyloFrame: A DataFrame-based Library for Fast, Flexible Phylogenetic Computation. arXiv preprint arXiv:2605.28545. https://doi.org/10.48550/arXiv.2605.28545"
+supporting_materials: |
+  - [software repository](https://github.com/mmore500/phyloframe) [via GitHub <i class="icon-github-1"></i>](https://github.com/)
+  - [software package](https://pypi.org/project/phyloframe/) [via PyPI](https://pypi.org/)
+  - [documentation](https://phyloframe.readthedocs.io) [via Read the Docs](https://readthedocs.org/)
+---


### PR DESCRIPTION
## Summary
This PR adds a new blog post documenting the PhyloFrame preprint publication to the efflux blog section.

## Changes
- Added new publication entry for "PhyloFrame: A DataFrame-based Library for Fast, Flexible Phylogenetic Computation"
- Includes complete publication metadata:
  - arXiv DOI and links (10.48550/arXiv.2605.28545)
  - Author information (Moreno, Sukumaran, Zaman, Dolson)
  - Publication date (2026-05-27)
  - Abstract describing the DataFrame-based phylogenetic computation library
  - BibTeX citation for academic referencing
  - Links to supporting materials (GitHub repository, PyPI package, Read the Docs documentation)

## Details
The post documents PhyloFrame, a Python library designed for scalable phylogenetic computation on very large trees (≥300,000 taxa) using DataFrame-based representation and JIT compilation/vectorization support.

https://claude.ai/code/session_01GmRfURoATvtBxeoG3cBdvc